### PR TITLE
Add comprehensive tests and fix permission check

### DIFF
--- a/models/usuario.py
+++ b/models/usuario.py
@@ -58,7 +58,8 @@ class Usuario:
         self._telefono = str(telefono)
 
     def tiene_permiso(self, accion:str) -> bool:
-        return str(accion) in set(p.lower() for p in self._permisos)
+        permisos_normalizados = {str(p).lower() for p in self._permisos}
+        return str(accion).lower() in permisos_normalizados
 
     # ---- PRUEBAS (comentadas) ----
     # u = Usuario(1,"Luis","admin","a@b.com","3000000",[],["crear","leer"]) 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_estacion.py
+++ b/tests/test_estacion.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from models import EstacionMeteorologica, LecturaClimatica
+
+
+def crear_estacion(capacidad=3):
+    estacion = EstacionMeteorologica(
+        id=1,
+        nombre="EM-1",
+        latitud=6.2,
+        longitud=-75.6,
+        altitud=1500.0,
+        tipo="automática",
+        capacidad_registro=capacidad,
+        activa=True,
+    )
+    estacion.crear_estacion()
+    return estacion
+
+
+def crear_lectura(identificador: int, instante: datetime) -> LecturaClimatica:
+    return LecturaClimatica(
+        id=identificador,
+        estacion_id=1,
+        sensor_id=None,
+        fecha_hora=instante,
+        temperatura=20.5,
+        humedad=60.0,
+        fuente="sensor",
+        calidad_dato="ok",
+    )
+
+
+def test_registrar_y_filtrar_lecturas():
+    estacion = crear_estacion()
+    ahora = datetime.now()
+    lectura_1 = crear_lectura(1, ahora - timedelta(hours=1))
+    lectura_2 = crear_lectura(2, ahora)
+
+    estacion.registrar_lectura(lectura_1)
+    estacion.registrar_lectura(lectura_2)
+
+    lecturas = estacion.obtener_lecturas((ahora - timedelta(hours=2), ahora + timedelta(minutes=1)))
+    assert [l.id for l in lecturas] == [1, 2]
+
+
+def test_registrar_lectura_otro_id():
+    estacion = crear_estacion()
+    lectura = LecturaClimatica(
+        id=1,
+        estacion_id=999,
+        sensor_id=None,
+        fecha_hora=datetime.now(),
+    )
+
+    with pytest.raises(ValueError):
+        estacion.registrar_lectura(lectura)
+
+
+def test_capacidad_actua_como_fifo():
+    estacion = crear_estacion(capacidad=2)
+    base = datetime.now()
+    estacion.registrar_lectura(crear_lectura(1, base))
+    estacion.registrar_lectura(crear_lectura(2, base + timedelta(minutes=1)))
+    estacion.registrar_lectura(crear_lectura(3, base + timedelta(minutes=2)))
+
+    lecturas = estacion.obtener_lecturas((base - timedelta(minutes=1), base + timedelta(minutes=3)))
+    assert [l.id for l in lecturas] == [2, 3]

--- a/tests/test_lectura.py
+++ b/tests/test_lectura.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+
+from models import LecturaClimatica
+
+
+def test_variables_disponibles_y_validacion():
+    lectura = LecturaClimatica(
+        id=1,
+        estacion_id=10,
+        sensor_id=None,
+        fecha_hora=datetime(2024, 1, 1, 12, 0),
+        temperatura=22.5,
+        humedad=55.0,
+        precipitacion=3.2,
+        viento_vel=5.0,
+        viento_dir="N",
+        fuente="sensor",
+        calidad_dato="validada",
+    )
+
+    disponibles = lectura.variables_disponibles()
+    assert disponibles == {
+        "temperatura": 22.5,
+        "humedad": 55.0,
+        "precipitacion": 3.2,
+        "viento_vel": 5.0,
+    }
+
+    assert lectura.validar({
+        "temperatura": (0, 40),
+        "humedad": (0, 100),
+        "precipitacion": (0, 10),
+    })
+    assert not lectura.validar({"temperatura": (25, 30)})
+
+    linea = lectura.to_csv()
+    assert linea.startswith("1,10,")
+    assert ",sensor,validada" in linea

--- a/tests/test_parcela.py
+++ b/tests/test_parcela.py
@@ -1,0 +1,71 @@
+from models import FuenteAgua, Parcela, Suelo
+
+
+def test_asignar_suelo_y_fuentes():
+    parcela = Parcela(
+        id=1,
+        nombre="Parcela A",
+        latitud=6.2,
+        longitud=-75.6,
+        altitud=1500.0,
+        area_ha=5.0,
+        descripcion="Zona fértil",
+        propietario_id=10,
+    )
+
+    suelo = Suelo(
+        id=1,
+        parcela_id=1,
+        ph=6.5,
+        nutrientes="NPK medio",
+        textura="franco",
+        materia_organica=2.0,
+        clasificacion="A",
+    )
+
+    parcela.asignar_suelo(suelo)
+    assert parcela.suelo is suelo
+
+    fuente = FuenteAgua(
+        id=1,
+        parcela_id=1,
+        latitud=6.21,
+        longitud=-75.61,
+        tipo="quebrada",
+        calidad={"ph": 7.0},
+    )
+
+    parcela.agregar_fuente_agua(fuente)
+    assert parcela.listar_fuentes_agua() == [fuente]
+
+
+
+def test_suelo_es_apto_por_parametros_basicos():
+    suelo = Suelo(
+        id=2,
+        parcela_id=1,
+        ph=6.2,
+        nutrientes="rico",
+        textura="franco",
+        materia_organica=1.8,
+        clasificacion="A",
+    )
+    assert suelo.es_apto("maíz")
+
+    suelo.ph = 8.5
+    assert not suelo.es_apto("maíz")
+
+
+
+def test_fuente_agua_evalua_criterios():
+    fuente = FuenteAgua(
+        id=3,
+        parcela_id=1,
+        latitud=6.22,
+        longitud=-75.62,
+        tipo="pozo",
+        calidad={"ph": 7.2, "conductividad": 1.1},
+    )
+
+    assert fuente.es_apta_para_riego({"ph": (6.5, 7.5)})
+    assert not fuente.es_apta_para_riego({"conductividad": (0, 1)})

--- a/tests/test_prediccion.py
+++ b/tests/test_prediccion.py
@@ -1,0 +1,19 @@
+from datetime import date, timedelta
+
+from models import PrediccionClimatica
+
+
+def test_prediccion_consulta_y_resumen():
+    hoy = date.today()
+    prediccion = PrediccionClimatica(
+        id=1,
+        estacion_id=5,
+        fecha_emision=hoy,
+        variable="lluvia",
+        valor_previsto=12.3,
+        modelo_usado="ARIMA",
+        confiabilidad=0.8,
+    )
+
+    assert prediccion.consultar_por_fecha((hoy - timedelta(days=1), hoy + timedelta(days=1)))
+    assert "Predicción" in prediccion.mostrar_resumen()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,24 @@
+import pytest
+
+from models import SensorTemperatura
+
+
+def test_sensor_temperatura_descripcion_y_calibracion():
+    sensor = SensorTemperatura(id=1, precision=0.2, rango_min=-50, rango_max=60, estacion_id=1)
+    assert "SensorTemperatura" in sensor.descripcion()
+    assert sensor.valor_en_rango(0.0) is True
+
+    sensor.calibrar(0.05)
+    assert sensor.precision == pytest.approx(0.05)
+
+
+def test_sensor_valida_rangos_incorrectos():
+    with pytest.raises(ValueError):
+        SensorTemperatura(id=1, precision=0.1, rango_min=10, rango_max=5, estacion_id=1)
+
+
+@pytest.mark.parametrize("nuevo_valor", [0, -0.1])
+def test_calibrar_rechaza_precision_no_positiva(nuevo_valor):
+    sensor = SensorTemperatura(id=2, precision=0.2, rango_min=-10, rango_max=40, estacion_id=1)
+    with pytest.raises(ValueError):
+        sensor.calibrar(nuevo_valor)

--- a/tests/test_usuario.py
+++ b/tests/test_usuario.py
@@ -1,0 +1,36 @@
+from models import Usuario
+
+
+def test_asignar_parcela_y_actualizar_contacto():
+    usuario = Usuario(
+        id=1,
+        nombre="Laura",
+        rol="analista",
+        email="laura@demo.com",
+        telefono="3001234567",
+        zonas_interes=[],
+        permisos=["ver"],
+    )
+
+    usuario.asignar_parcela(10)
+    usuario.actualizar_contacto("nuevo@demo.com", "3010000000")
+
+    assert 10 in usuario.zonas_interes
+    assert usuario.email == "nuevo@demo.com"
+    assert usuario.telefono == "3010000000"
+
+
+def test_tiene_permiso_no_depende_de_mayusculas():
+    usuario = Usuario(
+        id=2,
+        nombre="Carlos",
+        rol="admin",
+        email="carlos@demo.com",
+        telefono="3000000000",
+        zonas_interes=[],
+        permisos=["Crear", "Listar"],
+    )
+
+    assert usuario.tiene_permiso("crear")
+    assert usuario.tiene_permiso("CREAR")
+    assert not usuario.tiene_permiso("eliminar")


### PR DESCRIPTION
## Summary
- normalize the permission check in `Usuario` so it treats actions case-insensitively
- introduce a pytest-based test suite covering sensors, stations, readings, parcels, predictions and users
- configure test discovery with a `conftest.py` helper for repository imports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc60b75470832dba536c31d09fa514